### PR TITLE
Fixes fastbootDependencies in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-md5",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"
   },
-  "fastbootDependencies": [
-    "blueimp-md5"
-  ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "fastbootDependencies": [
+      "blueimp-md5"
+    ]
   }
 }


### PR DESCRIPTION
Currently, running ember-md5 in Fastboot doesn't install `blueimp-md5` from Fastboot's generated package.json.

![screen shot 2018-02-16 at 15 56 56](https://user-images.githubusercontent.com/2046935/36316951-ac9f25a4-1333-11e8-980c-1fbeff70fbc3.png)

This is because the package.json's `fastbootDependencies` should be defined inside the `ember-addon` object. This PR simply fixes that issue.


